### PR TITLE
Add outline for autonomous Sora video agent

### DIFF
--- a/docs/sora_agent.md
+++ b/docs/sora_agent.md
@@ -1,0 +1,34 @@
+# Proposta per un agente autonomo video-musicale
+
+## Obiettivo
+Creare un agente autonomo che partendo da una traccia audio generata con Suno realizzi un video completo tramite Sora, gestendo l'intero flusso di lavoro di montaggio e post-produzione.
+
+## Architettura suggerita
+1. **Ingestione risorse**
+   - Recupero della traccia Suno (API o download manuale).
+   - Estrazione di metadati (bpm, struttura strofa/ritornello) tramite librerie come `librosa` o `essentia`.
+2. **Orchestrazione agentica**
+   - Utilizzare un framework di agenti (p.es. LangChain, CrewAI, Autogen) per coordinare più sotto-agenti:
+     - *Planner* per definire storyboard e prompt video.
+     - *Prompt engineer* per generare input ottimizzati per Sora in base ai metadati musicali.
+     - *Editor* per verificare la coerenza delle clip e richiedere iterazioni.
+3. **Integrazione con Sora**
+   - Se Sora offre API, automatizzare l'invio dei prompt e il download dei risultati.
+   - In assenza di API pubbliche, prevedere un modulo RPA (ad es. Playwright) che controlli l'interfaccia web.
+4. **Post-produzione automatizzata**
+   - Assemblaggio delle clip con `moviepy`, `ffmpeg` o `DaVinci Resolve` via scripting.
+   - Sincronizzazione con la traccia audio e applicazione di effetti aggiuntivi (titoli, transizioni).
+5. **Valutazione e iterazione**
+   - Analisi automatica della coerenza tra audio e video (rilevamento beat, sentiment).
+   - Eventuali prompt di revisione generati automaticamente.
+
+## Considerazioni pratiche
+- Verificare termini d'uso di Suno e Sora per l'automazione e la distribuzione dei contenuti.
+- Prevedere fallback manuali in caso di risultati insoddisfacenti dal modello video.
+- Gestire credenziali/API key tramite segreti sicuri.
+- Loggare ogni decisione dell'agente per auditing e debugging.
+
+## Estensioni possibili
+- Integrazione con strumenti di scrittura testi per generare storyboard o copioni.
+- Fine-tuning di modelli generativi ausiliari (immagini, prompt) per migliorare la coerenza visiva.
+- Dashboard per monitorare lo stato delle generazioni e scaricare le versioni finali.


### PR DESCRIPTION
## Summary
- add documentation describing a possible architecture for an autonomous workflow that turns a Suno track into a Sora-generated video
- highlight orchestration, integration, and post-production steps together with practical considerations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e2db96a8832db1e8dc0ee7e817ad